### PR TITLE
Update requirements for 2.10.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: a7a27871b4f54cb913b0c1233e675131e9b2099549af0840d32c36b7e91b104b
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - pcluster = pcluster.cli:main
     - awsbqueues = awsbatch.awsbqueues:main
@@ -28,12 +28,13 @@ requirements:
   run:
     - python
     - setuptools
-    - boto3 >=1.10.15
-    - tabulate >=0.8.6
+    - boto3 >=1.16.14
+    - tabulate >=0.8.6,<=0.8.7
     - future >=0.18.2
-    - pyyaml >=5.2
+    - pyyaml >=5.3.1
     - configparser >=4.0.2  # [py2k]
     - jinja2 >=2.11.0
+    - ipaddress >=1.0.22
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,6 @@ requirements:
     - pyyaml >=5.3.1
     - configparser >=4.0.2  # [py2k]
     - jinja2 >=2.11.0
-    - ipaddress >=1.0.22
 
 test:
   imports:


### PR DESCRIPTION
Requirements were too old for aws-parallelcluster 2.10.0 to work correctly. Update them here to match the requirements of the 2.10.0 release (https://github.com/aws/aws-parallelcluster/blob/v2.10.0/cli/requirements.txt).

See https://github.com/aws/aws-parallelcluster/issues/2251 for how I found this out.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
