### PR TITLE
updated v3.9.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   run:
     - python-jsii ==1.85.0
     - python >=3.7
-    - setuptools
+    - setuptools <70.0.0
     - boto3 >=1.16.14
     - tabulate >=0.8.8,<=0.8.10
     - pyyaml >=5.3.1,!=5.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-parallelcluster" %}
-{% set version = "3.9.1" %}
+{% set version = "3.9.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/aws-parallelcluster-{{ version }}.tar.gz
-  sha256: 57bcd9bb852db58db8e507882fa0bdd8aee9513cde749c8650b885e4df93922e
+  sha256: 84994b780eb19fa2046d0d834623d5b870d6d9721b6bd278093bdcbacf499099
 
 build:
   entry_points:


### PR DESCRIPTION
* Update AWS ParallelCluster to version 3.9.2
* Enforce setuptools to be < 70.0.0 as required in https://github.com/aws/aws-parallelcluster/blob/release-3.9/cli/setup.py#L26

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
