### PR TITLE
[Release] Bump AWS ParallelCluster version to 3.10.1.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-parallelcluster" %}
-{% set version = "3.10.0" %}
+{% set version = "3.10.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/aws-parallelcluster-{{ version }}.tar.gz
-  sha256: bfee58fb477c5e51e31695630a4ccfa0374d6545f2b1654ab0860fed5e9efde5
+  sha256: 92adab86dbf5b65ffe411ed6422c26aab7fcdfdf0fadc91067595563e32a6aef
 
 build:
   entry_points:


### PR DESCRIPTION
Bump AWS ParallelCluster version to 3.10.1.